### PR TITLE
Add support for turning window shadows ON and OFF

### DIFF
--- a/payload_test/payload.mm
+++ b/payload_test/payload.mm
@@ -149,9 +149,6 @@ DAEMON_CALLBACK(DaemonCallback)
         sscanf(Tokens[2].c_str(), "%d", &Value);
         int Tags[2] = {0};
 
-        NSWindow * ns_window;
-        ns_window = [NSApp windowWithWindowNumber: WindowId];
-        
         Tags[0] |= kCGSNoShadowTagBit;
         if(Value == 1)
         {


### PR DESCRIPTION
Hi @koekeishiya, I'm working on modifying the `chunkwm` tiling plugin to remove shadows from all tiled windows in a desktop with `bsp` layout and for that I needed to add support for shadow manipulation to the scripting additions injected payload.

I was previously doing this with mySIMBL and winbuddy, but that's much more invasive, forces a border in windows that could conflict with chunkwm border plugin and most importantly would remove shadows from every window and I think having shadows on `float` desktops and floated windows on `bsp` desktops makes for a much nicer experience (although the later could be configurable as well, perhaps an unfocused border for these would be another approach).

Let me know if you think this addition to the `chwm-sa` project seems useful to you.

Also, would you be interested in me creating a PR for the modifications to the tiling plugin (once they're ready and worthy of sharing)? If so, do you have any guidelines or requests regarding the design and/or coding?

Thanks for all your work and for sharing it with the community, I find `chunkwm` and `khd` extremely useful and the code quite simple and elegant. Kudos!